### PR TITLE
build(fabric): 添加 Minecraft 26.2 支持

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,3 @@
-- Fixed mod name
+- Add support for minecraft 26.2
+- Add `/scoreboard objectives (bind/unbind)` command
+- Fixed the scoreboard failed to persist in minecraft versions 26.1+.

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,14 @@ preprocess {
 	def mc12109_fabric = createNode("1.21.9-fabric", 1_21_09, "mojang")
 	def mc12111_fabric = createNode("1.21.11-fabric", 1_21_11, "mojang")
 	def mc260102_fabric = createNode("26.1.2-fabric", 26_01_02, "mojang")
+	def mc260200_fabric = createNode("26.2-fabric", 26_02_00, "mojang")
 
 	mc12101_fabric.link(mc12102_fabric, null)
 	mc12102_fabric.link(mc12105_fabric, null)
 	mc12105_fabric.link(mc12109_fabric, null)
 	mc12109_fabric.link(mc12111_fabric, null)
 	mc12111_fabric.link(mc260102_fabric, null)
+	mc260102_fabric.link(mc260200_fabric, null)
 
 	for (final def node in getNodes()) {
 		findProject(node.project).ext.mcVersion = node.mcVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ mod_id=scoreboard-tools
 archives_base_name=ScoreboardTools
 maven_group=net.cjsah.mod.scoretools
 mc_version_range=1.21 26.2
-mod_version=3.2.1
+mod_version=3.2.2
 
 # Required Libraries
 dependencies.fabric_loader=0.19.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ mod_title=ScoreboardTools
 mod_id=scoreboard-tools
 archives_base_name=ScoreboardTools
 maven_group=net.cjsah.mod.scoretools
-mc_version_range=1.21 26.1.2
+mc_version_range=1.21 26.2
 mod_version=3.2.1
 
 # Required Libraries

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.json
+++ b/settings.json
@@ -5,6 +5,7 @@
     "1.21.5-fabric",
     "1.21.9-fabric",
     "1.21.11-fabric",
-    "26.1.2-fabric"
+    "26.1.2-fabric",
+    "26.2-fabric"
   ]
 }

--- a/src/main/java/net/cjsah/scbt/command/ScoreboardToolCommand.java
+++ b/src/main/java/net/cjsah/scbt/command/ScoreboardToolCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.cjsah.scbt.data.ScoreType;
@@ -30,15 +31,40 @@ import static net.minecraft.commands.Commands.literal;
 
 public class ScoreboardToolCommand {
 
-    public static void registerCriteria(ArgumentBuilder<CommandSourceStack, ?> builder, CommandBuildContext commandContext) {
+    public static void registerBind(ArgumentBuilder<CommandSourceStack, ?> builder) throws CommandSyntaxException {
+        builder
+            .then(literal("bind").then(iteratorScoreCommand(ScoreboardToolCommand::bind)))
+            .then(literal("unbind").then(iteratorScoreCommand(
+                (context, scoreType, mapper) -> unbind(context)
+            )));
+    }
+
+    public static void registerCriteria(ArgumentBuilder<CommandSourceStack, ?> builder, CommandBuildContext commandContext) throws CommandSyntaxException {
+        iteratorScore(builder, (node, scoreType, mapper) ->
+            resolveExecutor(node, commandContext, scoreType, mapper)
+        );
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> iteratorScoreCommand(ScoreFunction<CommandContext<CommandSourceStack>> command) throws CommandSyntaxException {
+        RequiredArgumentBuilder<CommandSourceStack, String> builder = argument("objective", ObjectiveArgument.objective());
+        iteratorScore(builder, (node, scoreType, mapper) ->
+            node.executes(context -> {
+                command.accept(context, scoreType, mapper);
+                return 1;
+            })
+        );
+        return builder;
+    }
+
+    private static void iteratorScore(ArgumentBuilder<CommandSourceStack, ?> builder, ScoreFunction<ArgumentBuilder<CommandSourceStack, ?>> consumer) throws CommandSyntaxException {
         for (ScoreType scoreType : ScoreType.values()) {
             ArgumentBuilder<CommandSourceStack, ?> node = literal(scoreType.getName());
             if (scoreType.getRecordType() == DummyRecordType.class) {
-                resolveExecutor(node, commandContext, scoreType, DummyRecordType.DUMMY);
+                consumer.accept(node, scoreType, DummyRecordType.DUMMY);
             } else {
                 for (Enum<?> recordType : scoreType.getRecordType().getEnumConstants()) {
                     ArgumentBuilder<CommandSourceStack, ?> arg = literal(recordType.name());
-                    resolveExecutor(arg, commandContext, scoreType, scoreType.getScoreMapper(recordType.ordinal()));
+                    consumer.accept(arg, scoreType, scoreType.getScoreMapper(recordType.ordinal()));
                     node.then(arg);
                 }
             }
@@ -129,6 +155,18 @@ public class ScoreboardToolCommand {
         });
     }
 
+    private static void bind(CommandContext<CommandSourceStack> context, ScoreType type, IScoreMapper scoreMapper) throws CommandSyntaxException {
+        ScoreboardToolContext scoreContext = ((ScoreboardToolFake) context.getSource().getServer()).scbt$getContext();
+        Objective objective = ObjectiveArgument.getObjective(context, "objective");
+        scoreContext.addScoreBind(objective, type, scoreMapper);
+    }
+
+    private static void unbind(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        ScoreboardToolContext scoreContext = ((ScoreboardToolFake) context.getSource().getServer()).scbt$getContext();
+        Objective objective = ObjectiveArgument.getObjective(context, "objective");
+        scoreContext.removeObjetive(objective);
+    }
+
     private static int schedule(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         return executeInternal(context, (internal, slot) -> {
             internal.setSchedule(slot, IntegerArgumentType.getInteger(context, "schedule"));
@@ -180,5 +218,10 @@ public class ScoreboardToolCommand {
     @FunctionalInterface
     private interface BiConsumer<T, R> {
         void accept(T t, R r) throws CommandSyntaxException;
+    }
+
+    @FunctionalInterface
+    private interface ScoreFunction<T> {
+        void accept(T builder, ScoreType scoreType, IScoreMapper mapper) throws CommandSyntaxException;
     }
 }

--- a/src/main/java/net/cjsah/scbt/mixin/BlockItemMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/BlockItemMixin.java
@@ -18,10 +18,12 @@ public class BlockItemMixin {
         method = "place",
         at = @At(
             value = "INVOKE",
-            //#if MC < 260000
-            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
-            //#else
+            //#if MC >= 260200
+            //$$ target = "Lnet/minecraft/advancements/triggers/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#elseif MC >= 260000
             //$$ target = "Lnet/minecraft/advancements/criterion/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#else
+            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
             //#endif
         )
     )

--- a/src/main/java/net/cjsah/scbt/mixin/BucketItemMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/BucketItemMixin.java
@@ -26,10 +26,12 @@ public class BucketItemMixin {
         method = "use",
         at = @At(
             value = "INVOKE",
-            //#if MC < 260000
-            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
-            //#else
+            //#if MC >= 260200
+            //$$ target = "Lnet/minecraft/advancements/triggers/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#elseif MC >= 260000
             //$$ target = "Lnet/minecraft/advancements/criterion/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#else
+            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
             //#endif
         )
     )

--- a/src/main/java/net/cjsah/scbt/mixin/FlintAndSteelItemMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/FlintAndSteelItemMixin.java
@@ -18,10 +18,12 @@ public class FlintAndSteelItemMixin {
         method = "useOn",
         at = @At(
             value = "INVOKE",
-            //#if MC < 260000
-            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
-            //#else
+            //#if MC >= 260200
+            //$$ target = "Lnet/minecraft/advancements/triggers/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#elseif MC >= 260000
             //$$ target = "Lnet/minecraft/advancements/criterion/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemInstance;)V"
+            //#else
+            target = "Lnet/minecraft/advancements/critereon/ItemUsedOnLocationTrigger;trigger(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V"
             //#endif
         )
     )

--- a/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
@@ -35,6 +35,9 @@ import net.minecraft.server.level.progress.ChunkProgressListenerFactory;
 //$$ import net.minecraft.world.level.gamerules.GameRules;
 //$$ import java.util.Optional;
 //$$ import net.minecraft.world.level.storage.SavedDataStorage;
+//#if MC >= 260200
+//$$ import net.minecraft.server.notifications.NotificationManager;
+//#endif
 //#else
 import net.minecraft.world.level.storage.DimensionDataStorage;
 //#endif
@@ -70,6 +73,9 @@ public abstract class MinecraftServerMixin implements ScoreboardToolFake {
         //$$ LevelLoadListener levelLoadListener,
         //#if MC >= 260000
         //$$ boolean propagatesCrashes,
+        //#if MC >= 260200
+        //$$ NotificationManager notificationManager,
+        //#endif
         //#endif
         //#else
         ChunkProgressListenerFactory chunkProgressListenerFactory,

--- a/src/main/java/net/cjsah/scbt/mixin/ScoreboardCommandMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/ScoreboardCommandMixin.java
@@ -6,6 +6,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.cjsah.scbt.command.ScoreboardToolCommand;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -21,23 +22,54 @@ import java.util.function.Predicate;
 @Mixin(ScoreboardCommand.class)
 public class ScoreboardCommandMixin {
 
-    @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
+    @WrapOperation(
+        method = "register",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;",
+            remap = false
+        )
+    )
     private static ArgumentBuilder<CommandSourceStack, ?> registerCommand(LiteralArgumentBuilder<CommandSourceStack> instance, Predicate<CommandSourceStack> predicate, Operation<ArgumentBuilder<CommandSourceStack, ?>> original) {
         ArgumentBuilder<CommandSourceStack, ?> builder = original.call(instance, predicate);
         ScoreboardToolCommand.registerCommand(builder);
         return builder;
     }
 
-    @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/RequiredArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", ordinal = 1, remap = false))
+    @WrapOperation(
+        method = "register",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/brigadier/builder/RequiredArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;",
+            ordinal = 1,
+            remap = false
+        )
+    )
     private static ArgumentBuilder<CommandSourceStack, ?> appendToolCriteria(
         RequiredArgumentBuilder<CommandSourceStack, ?> instance,
         ArgumentBuilder<CommandSourceStack, ?> argumentBuilder,
         Operation<ArgumentBuilder<CommandSourceStack, ?>> original,
         @Local CommandBuildContext commandBuildContext
-    ) {
+    ) throws CommandSyntaxException {
         ScoreboardToolCommand.registerCriteria(instance, commandBuildContext);
         return original.call(instance, argumentBuilder);
     }
+
+    @WrapOperation(
+        method = "register",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/commands/Commands;literal(Ljava/lang/String;)Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;",
+            ordinal = 1,
+            remap = false
+        )
+    )
+    private static LiteralArgumentBuilder<CommandSourceStack> appendBindCommand(String string, Operation<LiteralArgumentBuilder<CommandSourceStack>> original) throws CommandSyntaxException {
+        LiteralArgumentBuilder<CommandSourceStack> builder = original.call(string);
+        ScoreboardToolCommand.registerBind(builder);
+        return builder;
+    }
+
 
     @Inject(method = "removeObjective", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/scores/Scoreboard;removeObjective(Lnet/minecraft/world/scores/Objective;)V"))
     private static void removeToolObjective(CommandSourceStack source, Objective objective, CallbackInfoReturnable<Integer> cir) {

--- a/src/main/java/net/cjsah/scbt/mixin/ScoreboardCommandMixin.java
+++ b/src/main/java/net/cjsah/scbt/mixin/ScoreboardCommandMixin.java
@@ -70,7 +70,6 @@ public class ScoreboardCommandMixin {
         return builder;
     }
 
-
     @Inject(method = "removeObjective", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/scores/Scoreboard;removeObjective(Lnet/minecraft/world/scores/Objective;)V"))
     private static void removeToolObjective(CommandSourceStack source, Objective objective, CallbackInfoReturnable<Integer> cir) {
         ScoreboardToolCommand.removeObjective(source, objective);

--- a/versions/1.21.11-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
+++ b/versions/1.21.11-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
@@ -1,30 +1,30 @@
 package net.cjsah.scbt.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.datafixers.DataFixer;
 import net.cjsah.scbt.data.ScoreboardToolContext;
+import net.cjsah.scbt.data.ScoreboardToolSaveData;
 import net.cjsah.scbt.fake.ScoreboardToolFake;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraft.server.Services;
 import net.minecraft.server.WorldStem;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.progress.LevelLoadListener;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.world.level.storage.DimensionDataStorage;
 import net.minecraft.world.level.storage.LevelStorageSource;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.net.Proxy;
 import java.util.function.BooleanSupplier;
-
-//#if MC >= 12109
-//$$ import net.minecraft.server.level.progress.LevelLoadListener;
-//#else
-import net.minecraft.server.level.progress.ChunkProgressListenerFactory;
-//#endif
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin implements ScoreboardToolFake {
@@ -44,23 +44,15 @@ public abstract class MinecraftServerMixin implements ScoreboardToolFake {
         Proxy proxy,
         DataFixer dataFixer,
         Services services,
-        //#if MC >= 12109
-        //$$ LevelLoadListener levelLoadListener,
-        //#else
-        ChunkProgressListenerFactory chunkProgressListenerFactory,
-        //#endif
+        LevelLoadListener levelLoadListener,
         CallbackInfo ci
     ) {
         this.scbt$scoreboardContext = new ScoreboardToolContext(this.getScoreboard());
     }
 
-    @Inject(method = "readScoreboard", at = @At("RETURN"))
-    private void injectSaveData(DimensionDataStorage savedDataStorage, CallbackInfo ci) {
-        //#if MC >= 12105
-        //$$ savedDataStorage.computeIfAbsent(ScoreboardToolContext.TYPE);
-        //#else
-        savedDataStorage.computeIfAbsent(this.scbt$scoreboardContext.dataFactory(), "scoreboard_tool_data");
-        //#endif
+    @Inject(method = "createLevels", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;load(Lnet/minecraft/world/scores/ScoreboardSaveData$Packed;)V", shift = At.Shift.AFTER))
+    private void injectSaveData(CallbackInfo ci, @Local DimensionDataStorage savedDataStorage) {
+        this.scbt$scoreboardContext.load(savedDataStorage.computeIfAbsent(ScoreboardToolSaveData.TYPE).getData());
     }
 
     @Inject(
@@ -73,6 +65,15 @@ public abstract class MinecraftServerMixin implements ScoreboardToolFake {
     )
     private void scoreboardTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
         this.scbt$scoreboardContext.getScheduler().tick();
+    }
+
+    @Shadow
+    @Final
+    public abstract ServerLevel overworld();
+
+    @Inject(method = "saveAllChunks", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;storeToSaveDataIfDirty(Lnet/minecraft/world/scores/ScoreboardSaveData;)V", shift = At.Shift.AFTER))
+    private void saveScoreContext(boolean bl, boolean bl2, boolean bl3, CallbackInfoReturnable<Boolean> cir) {
+        this.scbt$scoreboardContext.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardToolSaveData.TYPE));
     }
 
     @Override

--- a/versions/26.1.2-fabric/gradle.properties
+++ b/versions/26.1.2-fabric/gradle.properties
@@ -1,3 +1,3 @@
 # Dependency Versions
-minecraft_dependency=>=26.1-
+minecraft_dependency=>=26.1- <26.2-
 minecraft_version=26.1.2

--- a/versions/26.1.2-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
+++ b/versions/26.1.2-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
@@ -1,0 +1,97 @@
+package net.cjsah.scbt.mixin;
+
+import com.mojang.datafixers.DataFixer;
+import net.cjsah.scbt.data.ScoreboardToolContext;
+import net.cjsah.scbt.data.ScoreboardToolSaveData;
+import net.cjsah.scbt.fake.ScoreboardToolFake;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerScoreboard;
+import net.minecraft.server.Services;
+import net.minecraft.server.WorldStem;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.progress.LevelLoadListener;
+import net.minecraft.server.packs.repository.PackRepository;
+import net.minecraft.world.level.gamerules.GameRules;
+import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraft.world.level.storage.SavedDataStorage;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.Proxy;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+//#if MC >= 260200
+//$$ import net.minecraft.server.notifications.NotificationManager;
+//#endif
+
+@Mixin(MinecraftServer.class)
+public abstract class MinecraftServerMixin implements ScoreboardToolFake {
+
+    @Final
+    @Shadow
+    private SavedDataStorage savedDataStorage;
+
+    @Unique
+    private ScoreboardToolContext scbt$scoreboardContext;
+
+    @Shadow
+    public abstract ServerScoreboard getScoreboard();
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void init(
+        Thread serverThread,
+        LevelStorageSource.LevelStorageAccess storageSource,
+        PackRepository packRepository,
+        WorldStem worldStem,
+        Optional<GameRules> gameRules,
+        Proxy proxy,
+        DataFixer fixerUpper,
+        Services services,
+        LevelLoadListener levelLoadListener,
+        boolean propagatesCrashes,
+        //#if MC >= 260200
+        //$$ NotificationManager notificationManager,
+        //#endif
+        CallbackInfo ci
+    ) {
+        this.scbt$scoreboardContext = new ScoreboardToolContext(this.getScoreboard());
+    }
+
+    @Inject(method = "createLevels", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;load(Lnet/minecraft/world/scores/ScoreboardSaveData$Packed;)V", shift = At.Shift.AFTER))
+    private void injectSaveData(CallbackInfo ci) {
+        this.scbt$scoreboardContext.load(savedDataStorage.computeIfAbsent(ScoreboardToolSaveData.TYPE).getData());
+    }
+
+    @Inject(
+        method = "tickChildren",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V",
+            ordinal = 0
+        )
+    )
+    private void scoreboardTick(BooleanSupplier haveTime, CallbackInfo ci) {
+        this.scbt$scoreboardContext.getScheduler().tick();
+    }
+
+    @Shadow
+    @Final
+    public abstract ServerLevel overworld();
+
+    @Inject(method = "saveAllChunks", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;storeToSaveDataIfDirty(Lnet/minecraft/world/scores/ScoreboardSaveData;)V", shift = At.Shift.AFTER))
+    private void saveScoreContext(boolean silent, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
+        this.scbt$scoreboardContext.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardToolSaveData.TYPE));
+    }
+
+    @Override
+    public ScoreboardToolContext scbt$getContext() {
+        return this.scbt$scoreboardContext;
+    }
+}

--- a/versions/26.1.2-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
+++ b/versions/26.1.2-fabric/src/main/java/net/cjsah/scbt/mixin/MinecraftServerMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraft.server.Services;
 import net.minecraft.server.WorldStem;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.progress.LevelLoadListener;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.world.level.gamerules.GameRules;
@@ -66,7 +65,7 @@ public abstract class MinecraftServerMixin implements ScoreboardToolFake {
 
     @Inject(method = "createLevels", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;load(Lnet/minecraft/world/scores/ScoreboardSaveData$Packed;)V", shift = At.Shift.AFTER))
     private void injectSaveData(CallbackInfo ci) {
-        this.scbt$scoreboardContext.load(savedDataStorage.computeIfAbsent(ScoreboardToolSaveData.TYPE).getData());
+        this.scbt$scoreboardContext.load(this.savedDataStorage.computeIfAbsent(ScoreboardToolSaveData.TYPE).getData());
     }
 
     @Inject(
@@ -81,13 +80,9 @@ public abstract class MinecraftServerMixin implements ScoreboardToolFake {
         this.scbt$scoreboardContext.getScheduler().tick();
     }
 
-    @Shadow
-    @Final
-    public abstract ServerLevel overworld();
-
     @Inject(method = "saveAllChunks", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerScoreboard;storeToSaveDataIfDirty(Lnet/minecraft/world/scores/ScoreboardSaveData;)V", shift = At.Shift.AFTER))
     private void saveScoreContext(boolean silent, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
-        this.scbt$scoreboardContext.storeToSaveDataIfDirty(this.overworld().getDataStorage().computeIfAbsent(ScoreboardToolSaveData.TYPE));
+        this.scbt$scoreboardContext.storeToSaveDataIfDirty(this.savedDataStorage.computeIfAbsent(ScoreboardToolSaveData.TYPE));
     }
 
     @Override

--- a/versions/26.2-fabric/gradle.properties
+++ b/versions/26.2-fabric/gradle.properties
@@ -1,0 +1,3 @@
+# Dependency Versions
+minecraft_dependency=>=26.2- <26.3-
+minecraft_version=26.2


### PR DESCRIPTION
- 新增 26.2 Fabric 预处理与构建节点
- 调整 26.1.2 和 26.2 的 Minecraft 兼容范围
- 将聚合发行版本范围扩展到 26.2